### PR TITLE
Add simple error to indicate that form has empty required fields

### DIFF
--- a/src/components/withForm/abstracts/withForm.js
+++ b/src/components/withForm/abstracts/withForm.js
@@ -354,6 +354,11 @@ const withForm = (fields: FieldsType, options: OptionsType = {}) => (Component: 
             const { ok, validationErrors } = result
             return ok ? handleSuccess(result) : handleFailure(validationErrors)
           }
+          return handleFailure([{
+            title: 'Incomplete Form',
+            message: 'Required fields (marked with *) are not filled. Please fill them before submitting.',
+            key: 0,
+          }])
         } catch (err) {
           const networkError = [{
             key: 'networkError',


### PR DESCRIPTION
- [x] Add simple error to indicate that form has empty required fields

Possible enhancements:
- Indicate missed fields by highlighting them (e.g. setting `error` prop for SUI components which will give it a red background/border

Other way to do this:
- Disable Save button until all required fields are filled in