### PR TITLE
Fix retrieving of hidden prop for checkbox

### DIFF
--- a/src/components/withForm/abstracts/withFormComponents.js
+++ b/src/components/withForm/abstracts/withFormComponents.js
@@ -162,7 +162,6 @@ const withFormComponents = compose(
                   )
                 }
                 case FIELD_CHECKBOX: {
-                  const { hidden } = rest
                   return (
                     <Form.Field className={CLASS_FIELD_CHECKBOX} key={key} hidden={hidden} required={required}>
                       <Label className={CLASS_LABEL_CHECKBOX} />


### PR DESCRIPTION
Hidden prop for checkbox is being retrieved from the wrong object. It is already deconstructed from `fieldProps` in line 93, and not living in `rest` variable which contains the rest of the properties that have not been deconstructed from `fieldProps` .